### PR TITLE
Update localization strings for onboarding call-to-action in English …

### DIFF
--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -112,7 +112,7 @@
     "step3Cta": "Weiter",
     "step4Title": "Bereit zum Kochen!",
     "step4Message": "Starte mit deinem ersten Rezept. Nutze den grünen „+“-Button oder erkunde die Entdecken-Seite.",
-    "step4CtaPrimary": "Mein erstes Rezept hinzufügen",
+    "step4CtaPrimary": "Jetzt Rezepte entdecken",
     "step4CtaSecondary": "Später",
     "step4DontShowAgain": "Nicht wieder anzeigen",
     "skip": "Überspringen",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -104,7 +104,7 @@
     "step3Cta": "Next",
     "step4Title": "Ready to cook!",
     "step4Message": "Start by adding your first recipe. Use the green '+' button or explore the Discover page.",
-    "step4CtaPrimary": "Add my first recipe",
+    "step4CtaPrimary": "Discover recipes now",
     "step4CtaSecondary": "Skip for now",
     "step4DontShowAgain": "Don't show this again",
     "skip": "Skip",


### PR DESCRIPTION
…and German

- Changed the primary call-to-action text for onboarding from "Add my first recipe" to "Discover recipes now" in both English and German localization files to enhance user engagement.